### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ author=ItsPazaz
 email=ItsPazaz@gmail.com
 sentence=Output colors to a display using a ST7775 controller.
 paragraph=This library allows you to modify display RAM on an ST7775 display controller.
+category=Display
 url=https://github.com/Pazaz/TFT_2_ST7775
 architectures=*
 version=1.0


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library ST7775 Display Driver is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format